### PR TITLE
46 internal navigation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
       - postfix
 
 php:
- - 5.6
  - 7.0
  - 7.1
  - 7.2
@@ -23,44 +22,26 @@ env:
  global:
   - IGNORE_PATHS=js/jquery.js,tests/
  matrix:
-  - DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
   - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
   - DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_37_STABLE
   - DB=pgsql MOODLE_BRANCH=master
-  - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
   - DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
   - DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
   - DB=mysqli MOODLE_BRANCH=master
 
 matrix:
   fast_finish: true
   exclude:
-    - php: 5.6
-      env: DB=pgsql MOODLE_BRANCH=master
-    - php: 5.6
-      env: DB=mysqli MOODLE_BRANCH=master
-    - php: 5.6
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
-    - php: 5.6
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
-    - php: 5.6
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
-    - php: 5.6
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
-    - php: 5.6
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE
-    - php: 5.6
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE
+    - php: 7.0
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_37_STABLE
+    - php: 7.0
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_37_STABLE
     - php: 7.0
       env: DB=pgsql MOODLE_BRANCH=master
     - php: 7.0
       env: DB=mysqli MOODLE_BRANCH=master
-    - php: 7.2
-      env: DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE
-    - php: 7.2
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Added internal navigation element so that user can navigate between all Quickmail pages without returning to the course page.
+- Added a link to Quickmail from the course administration; Quickmail may now be used without explicitly adding the block to the course.
+- Various internal code cleanup fixes
+- Dropped support for Moodle 3.3-3.4 and added support for Moodle 3.7
+
 ## 3.3.7 (April 5, 2019)
 
 - Add activity modules as a default applicable format (supports the Poster module).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Quickmail is a Moodle block that provides selective, bulk emailing within course
 
 ## Requirements
 
-- Moodle 3.3 (build 2017051500 or later)
+- Moodle 3.4 (build 2017111300or later)
 
 ## Features
 
@@ -35,6 +35,8 @@ Teachers may define alternate emails for sending. These are available course-wid
 ## Installation
 
 Visit <https://github.com/CLAMP-IT/clampmail> to either download a package or clone the git repository. Then visit the admin screen to allow the install to complete.
+
+Quickmail will add a link to the course administration for accessing the module. While the block is still available for historical reasons it is not necessary for teachers to add the block to their course in order to use Quickmail.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Quickmail is a Moodle block that provides selective, bulk emailing within course
 
 ## Requirements
 
-- Moodle 3.4 (build 2017111300or later)
+- Moodle 3.5 (build 2018051700 or later)
 
 ## Features
 

--- a/alternate.php
+++ b/alternate.php
@@ -48,7 +48,7 @@ $PAGE->set_context($context);
 $PAGE->set_course($course);
 $PAGE->set_pagelayout('report');
 
-$PAGE->navbar->add($blockname);
+$PAGE->navbar->add($blockname, new moodle_url('/blocks/clampmail/email.php', array('courseid' => $courseid)));
 $PAGE->navbar->add($heading);
 
 $PAGE->set_title($title);

--- a/alternate.php
+++ b/alternate.php
@@ -53,6 +53,7 @@ $PAGE->navbar->add($heading);
 
 $PAGE->set_title($title);
 $PAGE->set_heading($title);
+$PAGE->set_pagetype($blockname);
 
 if (!method_exists('clampmail_alternate', $action)) {
     // Always fallback on view.
@@ -62,7 +63,11 @@ if (!method_exists('clampmail_alternate', $action)) {
 $body = clampmail_alternate::$action($course, $id);
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($heading);
+echo $OUTPUT->heading($blockname);
+echo block_clampmail\navigation::print_navigation(
+        block_clampmail\navigation::get_links($course->id, $context),
+        $heading
+);
 
 if ($flash) {
     echo $OUTPUT->notification(get_string('changessaved'), 'notifysuccess');

--- a/block_clampmail.php
+++ b/block_clampmail.php
@@ -44,69 +44,12 @@ class block_clampmail extends block_list {
             return $this->content;
         }
 
-        $this->content = new stdClass;
-        $this->content->items = array();
-        $this->content->icons = array();
-        $this->content->footer = '';
-
         $context = context_course::instance($COURSE->id);
 
-        $config = block_clampmail\config::load_configuration($COURSE);
-        $permission = has_capability('block/clampmail:cansend', $context);
-
-        $iconclass = array('class' => 'icon');
-
-        if ($permission) {
-            $cparam = array('courseid' => $COURSE->id);
-
-            $sendemail = html_writer::link(
-                new moodle_url('/blocks/clampmail/email.php', $cparam),
-                get_string('composenew', 'block_clampmail')
-            );
-            $this->content->items[] = $sendemail;
-            $this->content->icons[] = $OUTPUT->pix_icon('i/email', '', 'moodle', $iconclass);
-
-            $signature = html_writer::link(
-                new moodle_url('/blocks/clampmail/signature.php', $cparam),
-                get_string('manage_signatures', 'block_clampmail')
-            );
-            $this->content->items[] = $signature;
-            $this->content->icons[] = $OUTPUT->pix_icon('i/edit', '', 'moodle', $iconclass);
-
-            $draftparams = $cparam + array('type' => 'drafts');
-            $drafts = html_writer::link(
-                new moodle_url('/blocks/clampmail/emaillog.php', $draftparams),
-                get_string('drafts', 'block_clampmail')
-            );
-            $this->content->items[] = $drafts;
-            $this->content->icons[] = $OUTPUT->pix_icon('i/settings', '', 'moodle', $iconclass);
-
-            $history = html_writer::link(
-                new moodle_url('/blocks/clampmail/emaillog.php', $cparam),
-                get_string('log', 'block_clampmail')
-            );
-            $this->content->items[] = $history;
-            $this->content->icons[] = $OUTPUT->pix_icon('i/settings', '', 'moodle', $iconclass);
-        }
-
-        if (has_capability('block/clampmail:allowalternate', $context)) {
-            $alt = html_writer::link(
-                new moodle_url('/blocks/clampmail/alternate.php', $cparam),
-                get_string('alternate', 'block_clampmail')
-            );
-
-            $this->content->items[] = $alt;
-            $this->content->icons[] = $OUTPUT->pix_icon('i/edit', '', 'moodle', $iconclass);
-        }
-
-        if (has_capability('block/clampmail:canconfig', $context)) {
-            $config = html_writer::link(
-                new moodle_url('/blocks/clampmail/config.php', $cparam),
-                get_string('config', 'block_clampmail')
-            );
-            $this->content->items[] = $config;
-            $this->content->icons[] = $OUTPUT->pix_icon('i/settings', '', 'moodle', $iconclass);
-        }
+        $this->content = new stdClass;
+        $this->content->items = block_clampmail\navigation::get_links($COURSE->id, $context);
+        $this->content->icons = block_clampmail\navigation::get_icons($context);
+        $this->content->footer = '';
 
         return $this->content;
     }

--- a/classes/email_form.php
+++ b/classes/email_form.php
@@ -36,6 +36,15 @@ class email_form extends \moodleform {
     }
 
     /**
+     * Get the number of current and potential recipients.
+     *
+     * @return int
+     */
+    public function get_user_count() {
+        return count($this->_customdata['users']) + count($this->_customdata['selected']);
+    }
+
+    /**
      * Return formatted user display for the given user.
      * @param stdClass $user the user object.
      * @return string
@@ -122,30 +131,9 @@ class email_form extends \moodleform {
         }
         $groupoptions[0] = get_string('no_group', 'block_clampmail');
 
-        $links = array();
-        $genurl = function($type) use ($COURSE) {
-            $emailparam = array('courseid' => $COURSE->id, 'type' => $type);
-            return new \moodle_url('emaillog.php', $emailparam);
-        };
-
-        $draftlink = \html_writer::link ($genurl('drafts'), get_string('drafts', 'block_clampmail'));
-        $links[] =& $mform->createElement('static', 'draft_link', '', $draftlink);
-
         $context = \context_course::instance($COURSE->id);
 
         $config = config::load_configuration($COURSE);
-
-        $cansend = (
-            has_capability('block/clampmail:cansend', $context) or
-            !empty($config['allowstudents'])
-        );
-
-        if ($cansend) {
-            $historylink = \html_writer::link($genurl('log'), get_string('log', 'block_clampmail'));
-            $links[] =& $mform->createElement('static', 'history_link', '', $historylink);
-        }
-
-        $mform->addGroup($links, 'links', '&nbsp;', array(' | '), false);
 
         $reqimg = $OUTPUT->pix_icon('req', get_string('requiredelement', 'form'), 'moodle', array('class' => 'req'));
 

--- a/classes/navigation.php
+++ b/classes/navigation.php
@@ -1,0 +1,133 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package   block_clampmail
+ * @copyright 2019 Collaborative Liberal Arts Moodle Project
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_clampmail;
+
+defined('MOODLE_INTERNAL') || die();
+
+class navigation {
+
+    /**
+     * Get all the navigation icons.
+     *
+     * @param context $context the course context.
+     * @return array of navigation icons
+     */
+    public static function get_icons($context) {
+        global $OUTPUT;
+        $icons = array();
+
+        if (!has_capability('block/clampmail:cansend', $context)) {
+            // No navigation without this capability.
+            return $icons;
+        }
+
+        // Base icons.
+        $icons = [
+            $OUTPUT->pix_icon('i/email', '', 'moodle', array('class' => 'icon')),
+            $OUTPUT->pix_icon('i/edit', '', 'moodle', array('class' => 'icon')),
+            $OUTPUT->pix_icon('i/settings', '', 'moodle', array('class' => 'icon')),
+            $OUTPUT->pix_icon('i/settings', '', 'moodle', array('class' => 'icon')),
+        ];
+
+        // Alternate email icons.
+        if (has_capability('block/clampmail:allowalternate', $context)) {
+            $icons[] = $OUTPUT->pix_icon('i/edit', '', 'moodle', array('class' => 'icon'));
+        }
+
+        // Configuration icons.
+        if (has_capability('block/clampmail:canconfig', $context)) {
+            $icons[] = $OUTPUT->pix_icon('i/settings', '', 'moodle', array('class' => 'icon'));
+        }
+
+        return $icons;
+    }
+
+    /**
+     * Get all the navigation items.
+     *
+     * @param int $course the course id.
+     * @param context $context the course context.
+     * @return array of navigation links
+     */
+    public static function get_links($course, $context) {
+        $links = array();
+
+        if (!has_capability('block/clampmail:cansend', $context)) {
+            // No navigation without this capability.
+            return $links;
+        }
+
+        // Base links.
+        $links = [
+            \html_writer::link(
+                new \moodle_url('/blocks/clampmail/email.php', array('courseid' => $course)),
+                get_string('composenew', 'block_clampmail')
+            ),
+            \html_writer::link(
+                new \moodle_url('/blocks/clampmail/signature.php', array('courseid' => $course)),
+                get_string('manage_signatures', 'block_clampmail')
+            ),
+            \html_writer::link(
+                new \moodle_url('/blocks/clampmail/emaillog.php', array('courseid' => $course, 'type' => 'drafts')),
+                get_string('drafts', 'block_clampmail')
+            ),
+            \html_writer::link(
+                new \moodle_url('/blocks/clampmail/emaillog.php', array('courseid' => $course)),
+                get_string('log', 'block_clampmail')
+            )
+        ];
+
+        // Alternate email configuration link.
+        if (has_capability('block/clampmail:allowalternate', $context)) {
+            $links[] = \html_writer::link(
+                new \moodle_url('/blocks/clampmail/alternate.php', array('courseid' => $course)),
+                get_string('alternate', 'block_clampmail')
+            );
+        }
+
+        // Configuration link.
+        if (has_capability('block/clampmail:canconfig', $context)) {
+            $links[] = \html_writer::link(
+                new \moodle_url('/blocks/clampmail/config.php', array('courseid' => $course)),
+                get_string('config', 'block_clampmail')
+            );
+        }
+
+        return $links;
+    }
+
+    /**
+     * Display internal navigation.
+     *
+     * @param array $items the navigation items to display.
+     * @param string $heading the internal page heading.
+     * @return string rendered output
+     */
+    public static function print_navigation($items, $heading) {
+        global $OUTPUT;
+
+        $html = \html_writer::alist($items, array('class' => 'internal-navigation'));
+        $html .= $OUTPUT->heading($heading, '3');
+        return $html;
+    }
+}

--- a/config.php
+++ b/config.php
@@ -44,6 +44,7 @@ $PAGE->set_course($course);
 $PAGE->set_url('/blocks/clampmail/config.php', array('courseid' => $courseid));
 $PAGE->set_title($blockname . ': '. $header);
 $PAGE->set_heading($blockname. ': '. $header);
+$PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
 $PAGE->set_pagetype($blockname);
 $PAGE->set_pagelayout('standard');
@@ -79,7 +80,11 @@ $config['roleselection'] = explode(',', $config['roleselection']);
 $form->set_data($config);
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($header);
+echo $OUTPUT->heading($blockname);
+echo block_clampmail\navigation::print_navigation(
+        block_clampmail\navigation::get_links($course->id, $context),
+        $header
+);
 
 echo $OUTPUT->box_start();
 

--- a/config.php
+++ b/config.php
@@ -44,7 +44,7 @@ $PAGE->set_course($course);
 $PAGE->set_url('/blocks/clampmail/config.php', array('courseid' => $courseid));
 $PAGE->set_title($blockname . ': '. $header);
 $PAGE->set_heading($blockname. ': '. $header);
-$PAGE->navbar->add($blockname);
+$PAGE->navbar->add($blockname, new moodle_url('/blocks/clampmail/email.php', array('courseid' => $courseid)));
 $PAGE->navbar->add($header);
 $PAGE->set_pagetype($blockname);
 $PAGE->set_pagelayout('standard');

--- a/email.php
+++ b/email.php
@@ -115,12 +115,6 @@ if ($groupmode == SEPARATEGROUPS && !has_capability('block/clampmail:cansendtoal
     }
 }
 
-// Stop execution if there's no valid email target.
-$returnurl = new moodle_url('/course/view.php', array('id' => $course->id));
-if (empty($users)) {
-    notice(get_string('no_users', 'block_clampmail'), $returnurl);
-}
-
 if (!empty($type)) {
     $email = $DB->get_record('block_clampmail_'.$type, array('id' => $typeid));
     $email->messageformat = $email->format;
@@ -312,14 +306,24 @@ if (empty($warnings)) {
 
 echo $OUTPUT->header();
 echo $OUTPUT->heading($blockname);
+echo block_clampmail\navigation::print_navigation(
+        block_clampmail\navigation::get_links($course->id, $context),
+        get_string('composenew', 'block_clampmail')
+);
 
-foreach ($warnings as $type => $warning) {
-    $class = ($type == 'success') ? 'notifysuccess' : 'notifyproblem';
-    echo $OUTPUT->notification($warning, $class);
+// Don't show the form if there's no valid email target.
+$returnurl = new moodle_url('/course/view.php', array('id' => $course->id));
+if ($form->get_user_count() == 0) {
+    notice(get_string('no_users', 'block_clampmail'), $returnurl);
+} else {
+    foreach ($warnings as $type => $warning) {
+        $class = ($type == 'success') ? 'notifysuccess' : 'notifyproblem';
+        echo $OUTPUT->notification($warning, $class);
+    }
+
+    echo html_writer::start_tag('div', array('class' => 'no-overflow'));
+    $form->display();
+    echo html_writer::end_tag('div');
+
+    echo $OUTPUT->footer();
 }
-
-echo html_writer::start_tag('div', array('class' => 'no-overflow'));
-$form->display();
-echo html_writer::end_tag('div');
-
-echo $OUTPUT->footer();

--- a/email.php
+++ b/email.php
@@ -62,11 +62,10 @@ $alternates = $DB->get_records_menu('block_clampmail_alternate',
     $altparams, '', 'id, address');
 
 $blockname = get_string('pluginname', 'block_clampmail');
-$header = get_string('email', 'block_clampmail');
+$header = get_string('composenew', 'block_clampmail');
 
 $PAGE->set_context($context);
 $PAGE->set_course($course);
-$PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
 $PAGE->set_title($blockname . ': '. $header);
 $PAGE->set_heading($blockname . ': '.$header);

--- a/emaillog.php
+++ b/emaillog.php
@@ -67,7 +67,7 @@ $header = get_string($type, 'block_clampmail');
 
 $PAGE->set_context($coursecontext);
 $PAGE->set_course($course);
-$PAGE->navbar->add($blockname);
+$PAGE->navbar->add($blockname, new moodle_url('/blocks/clampmail/email.php', array('courseid' => $courseid)));
 $PAGE->navbar->add($header);
 $PAGE->set_title($blockname . ': ' . $header);
 $PAGE->set_heading($blockname . ': ' . $header);

--- a/emaillog.php
+++ b/emaillog.php
@@ -104,7 +104,11 @@ if ($canimpersonate and $USER->id != $userid) {
 }
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($header);
+echo $OUTPUT->heading($blockname);
+echo block_clampmail\navigation::print_navigation(
+        block_clampmail\navigation::get_links($course->id, $coursecontext),
+        $header
+);
 
 if ($canimpersonate) {
     $sql = "SELECT DISTINCT(l.userid), u.firstname, u.lastname, u.firstnamephonetic, u.lastnamephonetic, u.middlename, u.alternatename

--- a/lib.php
+++ b/lib.php
@@ -275,7 +275,6 @@ function block_clampmail_extend_navigation_course($navigation, $course, $context
         $url = new moodle_url('/blocks/clampmail/email.php', array('courseid' => $course->id));
         $node = navigation_node::create(get_string('pluginname', 'block_clampmail'), $url,
                 navigation_node::TYPE_SETTING, null, null, new pix_icon('i/email', get_string('pluginname', 'block_clampmail')));
-        $node->showinflatnavigation = true;
         $navigation->add_node($node);
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -262,3 +262,20 @@ function block_clampmail_pluginfile($course, $record, $context, $filearea, $args
         send_stored_file($file);
     }
 }
+
+/**
+ * Extends core navigation to display the Quickmail link in the course administration.
+ *
+ * @param navigation_node $navigation The navigation node to extend
+ * @param stdClass        $course The course object
+ * @param context         $context The course context
+ */
+function block_clampmail_extend_navigation_course($navigation, $course, $context) {
+    if (has_capability('block/clampmail:cansend', $context)) {
+        $url = new moodle_url('/blocks/clampmail/email.php', array('courseid' => $course->id));
+        $node = navigation_node::create(get_string('pluginname', 'block_clampmail'), $url,
+                navigation_node::TYPE_SETTING, null, null, new pix_icon('i/email', get_string('pluginname', 'block_clampmail')));
+        $node->showinflatnavigation = true;
+        $navigation->add_node($node);
+    }
+}

--- a/signature.php
+++ b/signature.php
@@ -90,7 +90,7 @@ $PAGE->set_title($course->shortname . ': '.
 $PAGE->set_heading($course->fullname);
 $PAGE->set_context($coursecontext);
 $PAGE->set_course($course);
-$PAGE->navbar->add($blockname);
+$PAGE->navbar->add($blockname, new moodle_url('/blocks/clampmail/email.php', array('courseid' => $courseid)));
 $PAGE->navbar->add($header);
 $PAGE->set_title($blockname . ': '. $header);
 $PAGE->set_heading($blockname . ': '.$header);

--- a/signature.php
+++ b/signature.php
@@ -82,10 +82,19 @@ $signature = file_prepare_standard_editor(
 );
 
 // Finish setting up the page.
+$blockname = get_string('pluginname', 'block_clampmail');
+$header = get_string('manage_signatures', 'block_clampmail');
 $PAGE->set_title($course->shortname . ': '.
     get_string('pluginname', 'block_clampmail') . ': '.
     get_string('signature', 'block_clampmail'));
 $PAGE->set_heading($course->fullname);
+$PAGE->set_context($coursecontext);
+$PAGE->set_course($course);
+$PAGE->navbar->add($blockname);
+$PAGE->navbar->add($header);
+$PAGE->set_title($blockname . ': '. $header);
+$PAGE->set_heading($blockname . ': '.$header);
+$PAGE->set_pagetype($blockname);
 
 // Create form.
 $mform = new block_clampmail\signature_form('signature.php', array(
@@ -95,7 +104,7 @@ $mform->set_data($signature);
 
 // Process form.
 if ($mform->is_cancelled()) {
-    redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
+    redirect(new moodle_url('/blocks/clampmail/email.php', array('courseid' => $courseid)));
 } else if ($fromform = $mform->get_data()) {
     if (!empty($fromform->delete)) {
         $delete = true;
@@ -131,6 +140,11 @@ if ($mform->is_cancelled()) {
 
 // Display header.
 echo $OUTPUT->header();
+echo $OUTPUT->heading($blockname);
+echo block_clampmail\navigation::print_navigation(
+        block_clampmail\navigation::get_links($course->id, $coursecontext),
+        $header
+);
 
 // Display notifications.
 if ($updated) {

--- a/styles.css
+++ b/styles.css
@@ -67,3 +67,26 @@
     display: inline-block;
     vertical-align: unset;
 }
+
+#page-Quickmail .internal-navigation {
+    display: flex;
+    list-style: none;
+    padding-left: 0;
+}
+
+#page-Quickmail .internal-navigation li {
+    list-style: none;
+}
+
+#page-Quickmail .internal-navigation li:first-child:before {
+    padding: 0;
+    content: "";
+}
+
+#page-Quickmail .internal-navigation li:not(:first-child):before {
+    display: inline-block;
+    padding-right: .5rem;
+    padding-left: .5rem;
+    color: #868e96;
+    content: "|";
+}

--- a/tests/behat/alt.feature
+++ b/tests/behat/alt.feature
@@ -16,15 +16,13 @@ Feature: Alternate email addresses
       | user     | course | role           |
       | teacher1 | CF101  | editingteacher |
       | teacher2 | CF101  | editingteacher |
-    And I log in as "teacher1"
-    And I am on "Test Course" course homepage
-    And I turn editing mode on
-    When I add the "Quickmail" block
-    Then I should see "Alternate emails"
 
   @javascript
   Scenario: Add alternate email
-    Given I follow "Alternate emails"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "Alternate emails"
     Then I should see "No alternate emails found for Test Course"
     When I press "Continue"
     Then I should see "Email address"
@@ -37,6 +35,7 @@ Feature: Alternate email addresses
     And I log out
     And I log in as "teacher2"
     And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
     And I follow "Alternate emails"
     And I should see "teacher1_alt@example.com"
     And I follow "Delete"

--- a/tests/behat/block.feature
+++ b/tests/behat/block.feature
@@ -1,0 +1,46 @@
+@block @block_clampmail
+Feature: Navigate with block
+  In order to use Quickmail
+  In a course with blocks
+  I need the ability to navigate from the block
+
+  Background:
+    Given the following "courses" exist:
+      | fullname    | shortname | category | groupmode |
+      | Test Course | CF101     | 0        | 1         |
+    And the following "users" exist:
+      | username | firstname | lastname | email | emailstop |
+      | teacher1 | Teacher | 1 | teacher1@example.com | 0 |
+      | student1 | Student | 1 | student1@example.com | 0 |
+      | student2 | Student | 2 | student2@example.com | 0 |
+      | student3 | Student | 3 | student3@example.com | 0 |
+      | student4 | Student | 4 | student4@example.com | 0 |
+      | student5 | Student | 5 | student5@example.com | 1 |
+    And the following "course enrolments" exist:
+      | user | course | role |
+      | teacher1 | CF101 | editingteacher |
+      | student1 | CF101 | student |
+      | student2 | CF101 | student |
+      | student3 | CF101 | student |
+      | student4 | CF101 | student |
+
+  @javascript
+  Scenario: Add the block
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage with editing mode on
+    And I add the "Quickmail" block
+    Then I should see "Compose new email"
+    And I should see "View history"
+    And I should see "View drafts"
+    And I should see "Manage signatures"
+    And I should see "Alternate emails"
+    And I should see "Configuration"
+    And I log out
+    And I log in as "student1"
+    And I am on "Test Course" course homepage
+    Then I should not see "Compose new email"
+    And I should not see "View history"
+    And I should not see "View drafts"
+    And I should not see "Manage signatures"
+    And I should not see "Alternate emails"
+    And I should not see "Configuration"

--- a/tests/behat/compose.feature
+++ b/tests/behat/compose.feature
@@ -23,17 +23,12 @@ Feature: Send email
       | student2 | CF101 | student |
       | student3 | CF101 | student |
       | student4 | CF101 | student |
-    And I log in as "teacher1"
-    And I am on "Test Course" course homepage
-    And I turn editing mode on
-    And I add the "Quickmail" block
-    And I log out
 
   @javascript
   Scenario: Internal navigation
     Given I log in as "teacher1"
     And I am on "Test Course" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I follow "View drafts"
     Then I should see "You have no email drafts"
     When I press "Continue"
@@ -41,12 +36,25 @@ Feature: Send email
     Then I should see "You have no email history yet"
     When I press "Continue"
     Then I should see "Selected recipients"
+    And I follow "Manage signatures"
+    Then the "id" select box should contain "New signature"
+    When I press "Cancel"
+    Then I should see "Selected recipients"
+    When I follow "Alternate emails"
+    Then I should see "No alternate emails found for Test Course"
+    And I press "Continue"
+    And I set the following fields to these values:
+        | Email address | somebody@example.net |
+    And I press "Cancel"
+    Then I should see "No alternate emails found for Test Course"
+    When I follow "Configuration"
+    Then I should see "Prepend course name"
 
   @javascript
   Scenario: Teacher sends an attachment to everyone
     Given I log in as "teacher1"
     And I am on "Test Course" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I press "Add all"
     And I set the following fields to these values:
       | Subject | Doom At 11 |

--- a/tests/behat/configuration.feature
+++ b/tests/behat/configuration.feature
@@ -18,15 +18,13 @@ Feature: Block configuration
       | teacher1 | CF101  | editingteacher |
       | student1 | CF101  | student        |
       | student2 | CF101  | student        |
-    And I log in as "teacher1"
-    And I am on "Test Course" course homepage
-    And I turn editing mode on
-    When I add the "Quickmail" block
-    Then I should see "Configuration"
 
   @javascript
   Scenario: Reset system defaults
-    Given I follow "Configuration"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "Configuration"
     And I follow "Restore system defaults"
     And I should see "Changes saved"
     And the following fields match these values:
@@ -37,19 +35,25 @@ Feature: Block configuration
 
   @javascript
   Scenario: Filter roles
-    Given I follow "Configuration"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "Configuration"
     And I set the following fields to these values:
       | Roles to filter by | student |
     And I press "Save changes"
     Then I should see "Changes saved"
     When I follow "Test Course"
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     Then the "roles" select box should contain "Student"
     And the "roles" select box should not contain "Teacher"
 
   @javascript
   Scenario: Prepend course name
-    Given I follow "Configuration"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "Configuration"
     And I set the following fields to these values:
       | Prepend course name | Short name |
     And I press "Save changes"
@@ -58,19 +62,25 @@ Feature: Block configuration
 
   @javascript
   Scenario: Receive a copy
-    Given I follow "Configuration"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "Configuration"
     And I set the following fields to these values:
       | Receive a copy | Yes |
     And I press "Save changes"
     And I should see "Changes saved"
     Then I should see "Yes"
     When I follow "Test Course"
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     Then the field "receipt" matches value "1"
 
   @javascript
   Scenario: Group mode
-    Given I follow "Configuration"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "Configuration"
     And I set the following fields to these values:
       | Group mode | Visible groups |
     And I press "Save changes"

--- a/tests/behat/drafts.feature
+++ b/tests/behat/drafts.feature
@@ -18,15 +18,13 @@ Feature: Email drafts
       | teacher1 | CF101 | editingteacher |
       | student1 | CF101 | student |
       | student2 | CF101 | student |
-    And I log in as "teacher1"
-    And I am on "Test Course" course homepage
-    And I turn editing mode on
-    When I add the "Quickmail" block
-    Then I should see "View drafts"
 
   @javascript
   Scenario: View and delete drafts
-    Given I follow "View drafts"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "View drafts"
     Then I should see "You have no email drafts"
     When I press "Continue"
     Then I should see "Selected recipients"

--- a/tests/behat/groups.feature
+++ b/tests/behat/groups.feature
@@ -64,23 +64,12 @@ Feature: Send email to groups
       | block/clampmail:cansend | Allow      | student        | Course       | CF102     |
       | block/clampmail:cansend | Allow      | student        | Course       | CF100     |
       | block/clampmail:cansend | Allow      | student        | Course       | CF103     |
-    And I log in as "teacher1"
-    And I am on "Test Course Separate" course homepage
-    And I turn editing mode on
-    And I add the "Quickmail" block
-    And I am on "Test Course Visible" course homepage
-    And I add the "Quickmail" block
-    And I am on "Test Course NoGroups" course homepage
-    And I add the "Quickmail" block
-    And I am on "Test Course Separate NoGroups" course homepage
-    And I add the "Quickmail" block
-    And I log out
 
   @javascript
   Scenario: Teacher composes to a single group
     Given I log in as "teacher1"
     And I am on "Test Course Separate" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I set the following fields to these values:
       | groups | Group B |
     And I press "Add"
@@ -97,7 +86,7 @@ Feature: Send email to groups
   Scenario: Student uses separate groups
     Given I log in as "student1"
     And I am on "Test Course Separate" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I should not see "Student 3" in the "#from_users" "css_element"
     And I set the following fields to these values:
       | groups | Group A |
@@ -114,7 +103,7 @@ Feature: Send email to groups
   Scenario: Student uses visible groups
     Given I log in as "student1"
     And I am on "Test Course Visible" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I set the following fields to these values:
       | groups | Group C |
     And I press "Add"
@@ -134,7 +123,7 @@ Feature: Send email to groups
   Scenario: Student uses no groups
     Given I log in as "student1"
     And I am on "Test Course NoGroups" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I set the following fields to these values:
       | groups | Not in a group |
     And I press "Add"
@@ -157,7 +146,7 @@ Feature: Send email to groups
     And I log out
     And I log in as "student1"
     And I am on "Test Course Separate" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I set the following fields to these values:
       | groups | Group A,Group B |
     And I press "Add"
@@ -174,7 +163,7 @@ Feature: Send email to groups
   Scenario: Student emails when separate groups are set but no groups are defined
     Given I log in as "student1"
     And I am on "Test Course Separate NoGroups" course homepage
-    And I follow "Compose new email"
+    And I navigate to "Quickmail" in current page administration
     And I press "Add all"
     And I set the following fields to these values:
       | Subject | Doom At 11 |

--- a/tests/behat/history.feature
+++ b/tests/behat/history.feature
@@ -18,15 +18,13 @@ Feature: Email history
       | teacher1 | CF101 | editingteacher |
       | student1 | CF101 | student |
       | student2 | CF101 | student |
-    And I log in as "teacher1"
-    And I am on "Test Course" course homepage
-    And I turn editing mode on
-    When I add the "Quickmail" block
-    Then I should see "View history"
 
   @javascript
   Scenario: View and delete history
-    Given I follow "View history"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "View history"
     Then I should see "You have no email history yet"
     And I press "Continue"
     And I should see "Selected recipients"
@@ -51,6 +49,7 @@ Feature: Email history
     And I navigate to "Courses > Manage courses and categories" in site administration
     And I follow "Test Course"
     And I follow "View"
+    And I navigate to "Quickmail" in current page administration
     And I follow "View history"
     And I set the field "userid" to "Teacher 1"
     Then I should see "Hello World Redux"

--- a/tests/behat/signature.feature
+++ b/tests/behat/signature.feature
@@ -18,15 +18,13 @@ Feature: Email signatures
       | teacher1 | CF101 | editingteacher |
       | student1 | CF101 | student |
       | student2 | CF101 | student |
-    And I log in as "teacher1"
-    And I am on "Test Course" course homepage
-    And I turn editing mode on
-    When I add the "Quickmail" block
-    Then I should see "Manage signatures"
 
   @javascript
   Scenario: Add and remove signatures
-    Given I follow "Manage signatures"
+    Given I log in as "teacher1"
+    And I am on "Test Course" course homepage
+    And I navigate to "Quickmail" in current page administration
+    And I follow "Manage signatures"
     And I set the following fields to these values:
       | Signature | Doom At 11 |
       | default_flag | 1 |

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->version   = 2019040500; // The current module version (Date: YYYYMMDDXX).
-$plugin->requires  = 2017051500; // Requires this Moodle version.
+$plugin->requires  = 2018051700; // Requires this Moodle version.
 $plugin->component = 'block_clampmail'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE; // The current stability of this version (used for diagnostics).
 $plugin->release   = 'v3.3.7'; // The release name of this version (used for diagnostics).


### PR DESCRIPTION
Full list of changes:

- Drops Moodle 3.3-3.4 from supported versions.
- Adds a link to "Quickmail" in the course administration
- Adds a consistent internal subnavigation to the top of every Quickmail page.
- Removes the old "Drafts|History" navigation from the email form
- Changes when the "you have no users to email" message appears so that the navigation is always printed
- Ensures consistent breadcrumbs and page headers
- Adds a navigation class to return arrays of items and icons
- Modifies the signature page so that canceling the dialog takes you to email composition instead of the course page